### PR TITLE
dup.helper: re-add a version of the do_dup_src function

### DIFF
--- a/handlers/dup.helper.in
+++ b/handlers/dup.helper.in
@@ -51,6 +51,16 @@ do_dup_excludes() {
    set +o noglob
 }
 
+do_dup_src() {
+   do_dup_host_includes
+   [ $? = 0 ] || return 1
+   do_dup_excludes
+   [ $? = 0 ] || return 1
+
+   _src_done="(DONE)"
+   setDefault dest
+}
+
 do_dup_dest() {
 
    local replyconverted


### PR DESCRIPTION
Merge branch https://0xacab.org/ko7ashiV/backupninja/-/tree/hotfix/duphelper-readd-dodupsrc from Andrew Bezella.

Fixes https://0xacab.org/liberate/backupninja/-/issues/11332, https://0xacab.org/liberate/backupninja/-/issues/11336